### PR TITLE
fix backend flavor detection

### DIFF
--- a/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
@@ -830,8 +830,9 @@ abstract class XmlaOlap4jConnection implements OlapConnection {
         {
             final String dataSourceInfo =
                 conn.getOlapDatabase().getDataSourceInfo();
+            final String provider = conn.getOlapDatabase().getProviderName();
             for (BackendFlavor flavor : BackendFlavor.values()) {
-                if (dataSourceInfo.contains(flavor.token)) {
+                if (provider.contains(flavor.token) || dataSourceInfo.contains(flavor.token)) {
                     return flavor;
                 }
             }


### PR DESCRIPTION
the datasourceinfo isn't really suited to detect the backend flavor, SSAS returns "Microsoft Analysis Services" in the provider name, and the instance in the datasource info

keeping the old way for compatibility (probably essbase)