### PR TITLE
Update ivysettings.xml for new pentaho public repo

### DIFF
--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -1,19 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ivysettings>
-  <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true"/>
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false"/>
+  <properties environment="env" />
+  <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
+    override="false" />
+    
+  <!-- Repository for Pentaho-hosted artifacts -->  
+  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
+  <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 
-  <settings defaultResolver="default" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml"/>
-  <resolvers checkmodified="true" changingPattern=".*-SNAPSHOT">
-    <dual name="shared" checkmodified="true">
-      <url name="shared-ivy" changingPattern=".*-SNAPSHOT" checkmodified="true">
-        <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />
-      </url>
-      <ibiblio name="shared-mvn" m2compatible="true" root="http://repo.pentaho.org/artifactory/repo" checkmodified="true"/>
-    </dual>
+  <settings defaultResolver="pentaho-chained-resolver" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <resolvers>
+    <chain name="pentaho-chained-resolver">
+      <resolver ref="local" />
+      <dual name="pentaho">
+        <url name="pentaho-ivy" checkmodified="true" changingPattern=".*-SNAPSHOT.*">
+          <ivy pattern="${pentaho.resolve.repo}/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />
+        </url>
+        <ibiblio name="pentaho-mvn" m2compatible="true" root="${pentaho.resolve.repo}" />
+      </dual>
+      <ibiblio name="public-maven" root="${public.resolve.repo}" m2compatible="true" />
+    </chain>
   </resolvers>
-  <include url="${ivy.default.settings.dir}/ivysettings-local.xml"/>
-  <include url="${ivy.default.settings.dir}/ivysettings-main-chain.xml"/>
-  <include url="${ivy.default.settings.dir}/ivysettings-default-chain.xml"/>
+  <caches lockStrategy="artifact-lock" resolutionCacheDir="${ivy.default.ivy.user.dir}/resol-cache${env.EXECUTOR_NUMBER}" />
 </ivysettings>


### PR DESCRIPTION
Update ivysettings.xml with parameterized repo url.
Default points at the new pentaho public repository since the old one is in the process of being phased out.
