### PR TITLE
Fixes an issue in XmlaOlap4jCube where it would determine if Mondrian wa...

### DIFF
--- a/src/org/olap4j/driver/xmla/DeferredNamedListImpl.java
+++ b/src/org/olap4j/driver/xmla/DeferredNamedListImpl.java
@@ -89,7 +89,7 @@ class DeferredNamedListImpl<T extends Named>
                     state = State.POPULATING;
                     populateList(list);
                     state = State.POPULATED;
-                } catch (OlapException e) {
+                } catch (Exception e) {
                     state = State.NEW;
                     // TODO: fetch metadata on getCollection() method, so we
                     // can't get an exception while traversing the list

--- a/src/org/olap4j/driver/xmla/XmlaOlap4jCube.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jCube.java
@@ -18,6 +18,7 @@
 package org.olap4j.driver.xmla;
 
 import org.olap4j.OlapException;
+import org.olap4j.driver.xmla.XmlaOlap4jConnection.BackendFlavor;
 import org.olap4j.impl.*;
 import org.olap4j.mdx.IdentifierSegment;
 import org.olap4j.metadata.*;
@@ -462,9 +463,9 @@ class XmlaOlap4jCube implements Cube, Named
             List<String> memberUniqueNames,
             Map<String, XmlaOlap4jMember> memberMap) throws OlapException
         {
-            if (olap4jSchema.olap4jCatalog.olap4jDatabaseMetaData
-                    .olap4jConnection.getDatabase()
-                    .indexOf("Provider=Mondrian") != -1)
+            if (BackendFlavor.getFlavor(
+                olap4jSchema.olap4jCatalog.olap4jDatabaseMetaData
+                    .olap4jConnection, false).equals(BackendFlavor.MONDRIAN))
             {
                 mondrianMembersLookup(memberUniqueNames, memberMap);
             } else {

--- a/src/org/olap4j/driver/xmla/XmlaOlap4jStatement.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jStatement.java
@@ -77,12 +77,6 @@ abstract class XmlaOlap4jStatement implements OlapStatement {
         throw new UnsupportedOperationException();
     }
 
-    private void checkOpen() throws SQLException {
-        if (closed) {
-            throw getHelper().createException("closed");
-        }
-    }
-
     public int executeUpdate(String sql) throws SQLException {
         throw new UnsupportedOperationException();
     }
@@ -293,7 +287,7 @@ abstract class XmlaOlap4jStatement implements OlapStatement {
         final String propList = olap4jConnection.makeConnectionPropertyList();
 
         final String dataSourceInfo;
-        switch (olap4jConnection.getFlavor(true)) {
+        switch (BackendFlavor.getFlavor(olap4jConnection, true)) {
         case ESSBASE:
             dataSourceInfo =
                 olap4jConnection.getOlapDatabase().getDataSourceInfo();


### PR DESCRIPTION
...s the backend by looking at the DS name instead of XmlaOlap4jConnection.BackendFlavor.getFlavor. Also merges pull request #20 allowing the provider name to be used as a hint to determine the backend flavor. Also makes XmlaOlap4jConnection.DEBUG configurable via system properties. Also brings in patch #7 form sourceforge to prevent the DefferedNamedList form entering a stale state when an unchecked exception is thrown.