### PR TITLE
When using XMLA, the Measures Metadata should be loaded in Deffered mode

### DIFF
--- a/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
@@ -1529,6 +1529,13 @@ abstract class XmlaOlap4jConnection implements OlapConnection {
     }
 
     static class MeasureHandler extends HandlerImpl<XmlaOlap4jMeasure> {
+        private final XmlaOlap4jCube cubeForCallback;
+
+        public MeasureHandler(XmlaOlap4jCube cube) {
+            this.cubeForCallback = cube;
+        }
+    	
+    	
         public void handle(
             Element row,
             Context context,
@@ -1588,12 +1595,13 @@ abstract class XmlaOlap4jConnection implements OlapConnection {
                     + measureUniqueName);
             }
 
-            list.add(
-                new XmlaOlap4jMeasure(
+            XmlaOlap4jMeasure measure = new XmlaOlap4jMeasure(
                     (XmlaOlap4jLevel)member.getLevel(), measureUniqueName,
                     measureName, measureCaption, description, formatString,
                     null, measureAggregator, datatype, measureIsVisible,
-                    member.getOrdinal()));
+                    member.getOrdinal());
+            list.add(measure);
+            this.cubeForCallback.measuresMap.put(measure.getUniqueName(),measure);
         }
 
         public void sortList(List<XmlaOlap4jMeasure> list) {

--- a/src/org/olap4j/driver/xmla/XmlaOlap4jLevel.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jLevel.java
@@ -130,7 +130,7 @@ class XmlaOlap4jLevel
                             olap4jHierarchy.olap4jDimension,
                             olap4jHierarchy,
                             this),
-                        new XmlaOlap4jConnection.MeasureHandler(),
+                        new XmlaOlap4jConnection.MeasureHandler(olap4jHierarchy.olap4jDimension.olap4jCube),
                             restrictions));
             } else {
                 this.memberList = new DeferredNamedListImpl<XmlaOlap4jMember>(


### PR DESCRIPTION
This fixes the issue of one single MDX query to load ALL the measures metadata from all the cubes even when some of this cubes are not even used