### PR TITLE
provide charset encoding in content-type request header for xmla requests

### DIFF
--- a/src/org/olap4j/driver/xmla/proxy/XmlaOlap4jHttpProxy.java
+++ b/src/org/olap4j/driver/xmla/proxy/XmlaOlap4jHttpProxy.java
@@ -74,7 +74,8 @@ public class XmlaOlap4jHttpProxy extends XmlaOlap4jAbstractHttpProxy
             // Set headers
             urlConnection.setRequestProperty(
                 "content-type",
-                "text/xml");
+                "text/xml; charset="
+                    .concat(getEncodingCharsetName()));
             urlConnection.setRequestProperty(
                 "User-Agent",
                 "Olap4j("


### PR DESCRIPTION
In current implementation it's not clear which encoding is used for transport. This might result in broken passwords with umlauts when using e.g. iso-8859-1 for decoding the basic authentication token. With the charset information the destination is able to decode the token properly.