### PR TITLE
Defaulting LevelType to Regular if no mapping is found.

### DIFF
--- a/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
@@ -1512,8 +1512,8 @@ abstract class XmlaOlap4jConnection implements OlapConnection {
             final int levelNumber =
                 integerElement(row, "LEVEL_NUMBER");
             final Integer levelTypeCode = integerElement(row, "LEVEL_TYPE");
-            final Level.Type levelType =
-                Level.Type.getDictionary().forOrdinal(levelTypeCode);
+            Level.Type optionalLevelType = Level.Type.getDictionary().forOrdinal(levelTypeCode);
+            final Level.Type levelType = optionalLevelType == null ? Level.Type.REGULAR : optionalLevelType;
             boolean calculated = (levelTypeCode & MDLEVEL_TYPE_CALCULATED) != 0;
             final int levelCardinality =
                 integerElement(row, "LEVEL_CARDINALITY");


### PR DESCRIPTION
We are using Saiku to access a OLAP Cube backed by SQL Server 2008. We are now upgrading SQL Server 2008 to 2014. During this we noticed that some dimensions are getting LEVEL_TYPE which is not recognised by OLAP while getting the DiscoveryService. Two such examples are, 4484 for MonthOfYear, 4578 for QuaterOfYear. 

We are assuming this is because of a change in msmdpump.dll in SQL Server 2014 which is recognising more types. We saw the other commit https://github.com/olap4j/olap4j/commit/86fb2e8faf9d4235b347e6d6b707987256992898 which handles null pointer exception when level type is not recognised.

But there are other libraries also like saiku-query which also fail because of the same reason. So we thought if it would be a good idea to default the LEVEL_TYPE to REGULAR if it doesnt match with any of the existing types.

Thoughts?