### PR TITLE
Add support for hierarchy/measure display folder

### DIFF
--- a/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
@@ -1480,12 +1480,16 @@ abstract class XmlaOlap4jConnection implements OlapConnection {
                 stringElement(row, "ALL_MEMBER");
             final String defaultMemberUniqueName =
                 stringElement(row, "DEFAULT_MEMBER");
+            final String hierarchyDisplayFolder =
+                stringElement(row, "HIERARCHY_DISPLAY_FOLDER");
+
             XmlaOlap4jHierarchy hierarchy = new XmlaOlap4jHierarchy(
                 context.getDimension(row),
                 hierarchyUniqueName,
                 hierarchyName,
                 hierarchyCaption,
                 description,
+                hierarchyDisplayFolder,
                 allMember != null,
                 defaultMemberUniqueName);
             list.add(hierarchy);
@@ -1594,6 +1598,8 @@ abstract class XmlaOlap4jConnection implements OlapConnection {
                 stringElement(row, "DESCRIPTION");
             final String formatString =
                 stringElement(row, "DEFAULT_FORMAT_STRING");
+            final String measureDisplayFolder =
+                stringElement(row, "MEASURE_DISPLAY_FOLDER");
             final Measure.Aggregator measureAggregator =
                 Measure.Aggregator.getDictionary().forOrdinal(
                     integerElement(
@@ -1625,7 +1631,7 @@ abstract class XmlaOlap4jConnection implements OlapConnection {
             list.add(
                 new XmlaOlap4jMeasure(
                     (XmlaOlap4jLevel)member.getLevel(), measureUniqueName,
-                    measureName, measureCaption, description, formatString,
+                    measureName, measureCaption, description, formatString, measureDisplayFolder,
                     null, measureAggregator, datatype, measureIsVisible,
                     member.getOrdinal()));
         }

--- a/src/org/olap4j/driver/xmla/XmlaOlap4jHierarchy.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jHierarchy.java
@@ -32,12 +32,13 @@ import java.util.List;
  */
 class XmlaOlap4jHierarchy
     extends XmlaOlap4jElement
-    implements Hierarchy, Named
+    implements Hierarchy, DisplayFolder, Named
 {
     final XmlaOlap4jDimension olap4jDimension;
     final NamedList<XmlaOlap4jLevel> levels;
     private final boolean all;
     private final String defaultMemberUniqueName;
+    private final String hierarchyDisplayFolder;
 
     XmlaOlap4jHierarchy(
         XmlaOlap4jDimension olap4jDimension,
@@ -45,6 +46,7 @@ class XmlaOlap4jHierarchy
         String name,
         String caption,
         String description,
+        String hierarchyDisplayFolder,
         boolean all,
         String defaultMemberUniqueName) throws OlapException
     {
@@ -53,6 +55,7 @@ class XmlaOlap4jHierarchy
         this.olap4jDimension = olap4jDimension;
         this.all = all;
         this.defaultMemberUniqueName = defaultMemberUniqueName;
+        this.hierarchyDisplayFolder = hierarchyDisplayFolder;
 
         String[] hierarchyRestrictions = {
             "CATALOG_NAME",
@@ -111,6 +114,11 @@ class XmlaOlap4jHierarchy
         final NamedList<XmlaOlap4jMember> list =
             new NamedListImpl<XmlaOlap4jMember>(memberList);
         return Olap4jUtil.cast(list);
+    }
+
+    @Override
+    public String getDisplayFolder() {
+        return hierarchyDisplayFolder;
     }
 
     public boolean equals(Object obj) {

--- a/src/org/olap4j/driver/xmla/XmlaOlap4jMeasure.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jMeasure.java
@@ -31,11 +31,12 @@ import java.util.*;
  */
 class XmlaOlap4jMeasure
     extends XmlaOlap4jMember
-    implements Measure, Named
+    implements Measure, DisplayFolder, Named
 {
     private final Aggregator aggregator;
     private final Datatype datatype;
     private final boolean visible;
+    private String measureDisplayFolder;
 
     /**
      * Creates an XmlaOlap4jMeasure.
@@ -58,6 +59,7 @@ class XmlaOlap4jMeasure
         String caption,
         String description,
         final String formatString,
+        String measureDisplayFolder,
         String parentMemberUniqueName,
         Aggregator aggregator,
         Datatype datatype,
@@ -82,6 +84,7 @@ class XmlaOlap4jMeasure
         this.aggregator = aggregator;
         this.datatype = datatype;
         this.visible = visible;
+        this.measureDisplayFolder = measureDisplayFolder;
     }
 
     public Aggregator getAggregator() {
@@ -94,6 +97,11 @@ class XmlaOlap4jMeasure
 
     public boolean isVisible() {
         return visible;
+    }
+
+    @Override
+    public String getDisplayFolder() {
+        return measureDisplayFolder;
     }
 }
 

--- a/src/org/olap4j/metadata/DisplayFolder.java
+++ b/src/org/olap4j/metadata/DisplayFolder.java
@@ -1,0 +1,14 @@
+package org.olap4j.metadata;
+
+/**
+ * @author Joe Barefoot <joe.barefoot@atscale.com>
+ */
+public interface DisplayFolder {
+  /**
+   *  Returns the display folder for this Measure.
+   *
+   * @return display folder for this Measure
+   */
+  String getDisplayFolder();
+
+}

--- a/src/org/olap4j/metadata/DisplayFolder.java
+++ b/src/org/olap4j/metadata/DisplayFolder.java
@@ -1,7 +1,26 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
 package org.olap4j.metadata;
 
 /**
  * @author Joe Barefoot <joe.barefoot@atscale.com>
+ *
+ * @deprecated In olap4j 2.0, getDisplayFolder() will be on the Measure and Hierarchy interfaces
  */
 public interface DisplayFolder {
   /**


### PR DESCRIPTION
For reference from the olap4j spec, here are the two properties I'm trying to surface in the object model:
http://www.olap4j.org/olap4j_fs.html
HIERARCHY_DISPLAY_FOLDER
MEASURE_DISPLAY_FOLDER

...and here's the commit message for how it was done:
- add interface to support this without breaking other implementations e.g. Mondrian's
- add property to measure and hierarchy object models from the standard XMLA properties for folders

The key here is to not break Mondrian's implementations of Measure and Hierarchy.  Note also that apparently Mondrian has the notion of a "measureGroup"--I'm not sure how that differs from MEASURE_DISPLAY_FOLDER.  


Motivation and Saiku:

The goal of adding display folders is twofold:  1.  Our (AtScale) customers want to use olap4j for custom app development, and want folders.  2.  One of our customers is migrating from SSAS to AtScale, and wants to use a modified version of Saiku against both, and of course want folders to work.  I have also added display folder to Saiku's model as you can see in this fork diff:
https://github.com/OSBI/saiku/compare/development...AtScaleInc:atscale_add_folder_support

Usage is in the ObjectUtil convert* methods:
https://github.com/OSBI/saiku/compare/development...AtScaleInc:atscale_add_folder_support#diff-477feb83d9e3154910a1b94742b70195R115

Until DisplayFolder is available in an updated olap4j jar in some repo, the saiku fork has the built olap4j artifacts checked in temporarily so that one can do a local mvn install to test.  The goal is to also get the javascript modified for the front-end of saiku so that hierarchy folders work in its UI. 

(Sorry for the long PR description, but I thought folks might be interested in knowing there's actually a plan here.)