### PR TITLE
Fix for: [FATAL]:1:324866: Invalid byte 2 of 2-byte UTF-8 sequence (https://github.com/olap4j/olap4j/issues/25)

### DIFF
--- a/src/org/olap4j/driver/xmla/cache/XmlaOlap4jConcurrentMemoryCache.java
+++ b/src/org/olap4j/driver/xmla/cache/XmlaOlap4jConcurrentMemoryCache.java
@@ -22,6 +22,7 @@ import org.olap4j.driver.xmla.cache.XmlaOlap4jNamedMemoryCache.Property;
 import org.olap4j.impl.Olap4jUtil;
 
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -171,8 +172,8 @@ class XmlaOlap4jConcurrentMemoryCache {
             }
 
             // Return a copy to prevent corruption
-            return entry != null
-                ? new String(entry.getResponse()).getBytes()
+            return entry != null && entry.getResponse() != null
+                ? Arrays.copyOf(entry.getResponse(), entry.getResponse().length)
                 : null;
         }
     }


### PR DESCRIPTION
It corrupts data when system locale is different from Utf-8 and Xmla response encoded in Utf-8 and contains non english characters
//-- ? new String(entry.getResponse()).getBytes()
//++? Arrays.copyOf(entry.getResponse(), entry.getResponse().length)
